### PR TITLE
Fix how to decode CharStrings about subroutine calls, etc.

### DIFF
--- a/src/decodeCff.ml
+++ b/src/decodeCff.ml
@@ -1137,7 +1137,7 @@ let rec d_lexical_charstring ~(msg : string) ~(depth : int) (cconst : charstring
           begin
             match lcstate.last_number with
             | None ->
-                err @@ Error.InvalidCharstring(NoSubroutineIndex("local" ^ msg))
+                err @@ Error.InvalidCharstring(NoSubroutineIndex("local: " ^ msg))
 
             | Some(i) ->
                 if lcstate.lexical_lsubrs |> LexicalSubroutineIndex.mem i then
@@ -1150,7 +1150,7 @@ let rec d_lexical_charstring ~(msg : string) ~(depth : int) (cconst : charstring
           begin
             match lcstate.last_number with
             | None ->
-                err @@ Error.InvalidCharstring(NoSubroutineIndex("global, " ^ msg))
+                err @@ Error.InvalidCharstring(NoSubroutineIndex("global: " ^ msg))
 
             | Some(i) ->
                 if lcstate.lexical_gsubrs |> LexicalSubroutineIndex.mem i then
@@ -1196,9 +1196,9 @@ and d_lexical_subroutine ~(msg : string) ~(depth : int) ~(local : bool) (cconst 
         })
   in
 
-  transform_result @@ access_subroutine subrs i >>= fun (offset, length, _biased_number) ->
+  transform_result @@ access_subroutine subrs i >>= fun (offset, length, biased_number) ->
   let lcstate = { lcstate with lexical_lexing = { lcstate.lexical_lexing with remaining = length } } in
-  pick offset (d_lexical_charstring ~msg ~depth:(depth + 1) cconst lcstate) >>= fun (lcstate, acc) ->
+  pick offset (d_lexical_charstring ~msg:(Printf.sprintf "%s (biased: %d)" msg biased_number) ~depth:(depth + 1) cconst lcstate) >>= fun (lcstate, acc) ->
   let lcs = Alist.to_list acc in
 
   (* Adds the tokenized CharString and resets the remaining byte length. *)

--- a/src/decodeCff.ml
+++ b/src/decodeCff.ml
@@ -1130,10 +1130,9 @@ let rec d_lexical_charstring ~(msg : string) ~(depth : int) (cconst : charstring
   let open DecodeOperation in
   let open Intermediate.Cff in
   let rec aux (lcstate : lexical_charstring_state) (acc : charstring_token_and_info Alist.t) =
-    let cslstate = lcstate.lexical_lexing in
-    d_charstring_token cslstate >>= fun (lstate, cstoken) ->
+    d_charstring_token lcstate.lexical_lexing >>= fun (lstate, cstoken) ->
     let lcstate = { lcstate with lexical_lexing = lstate } in
-    let acc = Alist.extend acc (cstoken, cslstate.num_args, cslstate.num_stems) in
+    let acc = Alist.extend acc (cstoken, lstate.num_args, lstate.num_stems) in (* TEMPORARY *)
     let remaining = lstate.remaining in
 
     begin

--- a/src/decodeCff.ml
+++ b/src/decodeCff.ml
@@ -1137,7 +1137,8 @@ let rec d_lexical_charstring ~(msg : string) ~(depth : int) (cconst : charstring
           begin
             match lcstate.last_number with
             | None ->
-                err @@ Error.InvalidCharstring(NoSubroutineIndex("local: " ^ msg))
+                let tokens = Format.asprintf "%a" (Format.pp_print_list pp_charstring_token) (acc |> Alist.to_list) in
+                err @@ Error.InvalidCharstring(NoSubroutineIndex(Printf.sprintf "%s -> local, tokens: %s" msg tokens))
 
             | Some(i) ->
                 if lcstate.lexical_lsubrs |> LexicalSubroutineIndex.mem i then
@@ -1150,7 +1151,8 @@ let rec d_lexical_charstring ~(msg : string) ~(depth : int) (cconst : charstring
           begin
             match lcstate.last_number with
             | None ->
-                err @@ Error.InvalidCharstring(NoSubroutineIndex("global: " ^ msg))
+                let tokens = Format.asprintf "%a" (Format.pp_print_list pp_charstring_token) (acc |> Alist.to_list) in
+                err @@ Error.InvalidCharstring(NoSubroutineIndex(Printf.sprintf "%s -> global, tokens: %s" msg tokens))
 
             | Some(i) ->
                 if lcstate.lexical_gsubrs |> LexicalSubroutineIndex.mem i then

--- a/src/decodeCff.ml
+++ b/src/decodeCff.ml
@@ -1090,26 +1090,19 @@ end = struct
 
   module Impl = Map.Make(Int)
 
-  type t = (lexical_charstring option) Impl.t
+  type t = lexical_charstring Impl.t
 
   let empty = Impl.empty
 
-  let add i lcs = Impl.add i (Some(lcs))
+  let add i lcs = Impl.add i lcs
 
   let mem = Impl.mem
 
   let find i map =
-    match map |> Impl.find_opt i with
-    | None            -> None
-    | Some(None)      -> assert false
-    | Some(Some(lcs)) -> Some(lcs)
+    map |> Impl.find_opt i
 
   let fold f map acc =
-    Impl.fold (fun i opt acc ->
-      match opt with
-      | None      -> assert false
-      | Some(lcs) -> f i lcs acc
-    ) map acc
+    Impl.fold f map acc
 
   let cardinal = Impl.cardinal
 end
@@ -1182,7 +1175,7 @@ and d_lexical_subroutine ~(msg : string) ~(depth : int) ~(local : bool) (cconst 
   let open DecodeOperation in
 
   if depth > max_depth_limit then
-    err (Error.InvalidCharstring(ExceedMathDepthLimit(depth)))
+    err (Error.InvalidCharstring(ExceedMaxSubroutineDepth(depth)))
   else
 
     let remaining = lcstate.lexical_lexing.remaining in

--- a/src/decodeCff.ml
+++ b/src/decodeCff.ml
@@ -1338,7 +1338,7 @@ let assert_middle =
 let chop_last_of_list xs =
   let open ResultMonad in
   match List.rev xs with
-  | []               -> err Error.CharstringStackUnderflow
+  | []               -> err Error.EmptyCurveInCharstring
   | last :: main_rev -> return (List.rev main_rev, last)
 
 

--- a/src/decodeError.ml
+++ b/src/decodeError.ml
@@ -5,6 +5,17 @@ type unsupported_report =
   | CharstringArithmeticOperator of int
 [@@deriving show { with_path = false }]
 
+type charstring_error =
+  | UnknownLongOperator        of int
+  | StackUnderflow
+  | StackRemaining
+  | SubroutineIndexOutOfBounds of { index : int; biased : int }
+  | NoSubroutineIndex
+  | ParsingOverrun             of int
+  | NotAMiddleOfPath
+  | EmptyRestOfCurve
+[@@deriving show { with_path = false }]
+
 type t =
   | UnknownFormatVersion      of Value.Tag.t
   | UnknownTtcVersion         of wint
@@ -41,7 +52,7 @@ type t =
   | FdindexOutOfBounds        of int
   | FdselectOutOfBounds       of int
   | CharstringWithoutWidth
-  | InvalidCharstring
+  | InvalidCharstring         of charstring_error
   | InvalidTtfContour
   | UnknownCoverageFormat     of int
   | InvalidCoverageLength

--- a/src/decodeError.ml
+++ b/src/decodeError.ml
@@ -10,7 +10,7 @@ type charstring_error =
   | StackUnderflow
   | StackRemaining
   | SubroutineIndexOutOfBounds of { index : int; biased : int }
-  | NoSubroutineIndex
+  | NoSubroutineIndex          of string
   | ParsingOverrun             of int
   | NotAMiddleOfPath
   | EmptyRestOfCurve

--- a/src/decodeError.ml
+++ b/src/decodeError.ml
@@ -14,7 +14,7 @@ type charstring_error =
   | ParsingOverrun             of int
   | NotAMiddleOfPath
   | EmptyRestOfCurve
-  | ExceedMathDepthLimit       of int
+  | ExceedMaxSubroutineDepth   of int
 [@@deriving show { with_path = false }]
 
 type t =

--- a/src/decodeError.ml
+++ b/src/decodeError.ml
@@ -5,18 +5,6 @@ type unsupported_report =
   | CharstringArithmeticOperator of int
 [@@deriving show { with_path = false }]
 
-type charstring_error =
-  | UnknownLongOperator        of int
-  | StackUnderflow
-  | StackRemaining
-  | SubroutineIndexOutOfBounds of { index : int; biased : int }
-  | NoSubroutineIndex          of string
-  | ParsingOverrun             of int
-  | NotAMiddleOfPath
-  | EmptyRestOfCurve
-  | ExceedMaxSubroutineDepth   of int
-[@@deriving show { with_path = false }]
-
 type t =
   | UnknownFormatVersion      of Value.Tag.t
   | UnknownTtcVersion         of wint
@@ -53,7 +41,15 @@ type t =
   | FdindexOutOfBounds        of int
   | FdselectOutOfBounds       of int
   | CharstringWithoutWidth
-  | InvalidCharstring         of charstring_error
+  | UnknownCharstringLongOperator of int
+  | CharstringStackUnderflow
+  | CharstringStackRemaining
+  | SubroutineIndexOutOfBounds    of { index : int; biased : int }
+  | NoSubroutineIndexArgument
+  | CharstringParsingOverrun      of int
+  | NotAMiddleOfPathInCharstring
+  | EmptyCurveInCharstring
+  | ExceedMaxSubroutineDepth      of int
   | InvalidTtfContour
   | UnknownCoverageFormat     of int
   | InvalidCoverageLength

--- a/src/decodeError.ml
+++ b/src/decodeError.ml
@@ -14,6 +14,7 @@ type charstring_error =
   | ParsingOverrun             of int
   | NotAMiddleOfPath
   | EmptyRestOfCurve
+  | ExceedMathDepthLimit       of int
 [@@deriving show { with_path = false }]
 
 type t =

--- a/src/encodeTtf.ml
+++ b/src/encodeTtf.ml
@@ -168,7 +168,7 @@ let e_composite_glyph (composite_glyph : Ttf.composite_glyph_description) : unit
           | Ttf.Matching(i, j) -> (false, i, j)
         in
         let (arg_1_and_2_are_words, e_arg) =
-          if -256 <= arg1 && arg1 < 256 && -256 <= arg2 && arg2 < 256 then
+          if -128 <= arg1 && arg1 < 128 && -128 <= arg2 && arg2 < 128 then
             (false, e_int8)
           else
             (true, e_int16)

--- a/src/otfed.mli
+++ b/src/otfed.mli
@@ -835,6 +835,17 @@ module Decode : sig
       | CharstringArithmeticOperator of int
     [@@deriving show]
 
+    type charstring_error =
+      | UnknownLongOperator        of int
+      | StackUnderflow
+      | StackRemaining
+      | SubroutineIndexOutOfBounds of { index : int; biased : int }
+      | NoSubroutineIndex
+      | ParsingOverrun             of int
+      | NotAMiddleOfPath
+      | EmptyRestOfCurve
+    [@@deriving show]
+
     type t =
       | UnknownFormatVersion      of Value.Tag.t
       | UnknownTtcVersion         of wint
@@ -868,7 +879,7 @@ module Decode : sig
       | FdindexOutOfBounds        of int
       | FdselectOutOfBounds       of int
       | CharstringWithoutWidth
-      | InvalidCharstring
+      | InvalidCharstring         of charstring_error
       | InvalidTtfContour
       | UnknownCoverageFormat     of int
       | InvalidCoverageLength

--- a/src/otfed.mli
+++ b/src/otfed.mli
@@ -835,18 +835,6 @@ module Decode : sig
       | CharstringArithmeticOperator of int
     [@@deriving show]
 
-    type charstring_error =
-      | UnknownLongOperator        of int
-      | StackUnderflow
-      | StackRemaining
-      | SubroutineIndexOutOfBounds of { index : int; biased : int }
-      | NoSubroutineIndex          of string
-      | ParsingOverrun             of int
-      | NotAMiddleOfPath
-      | EmptyRestOfCurve
-      | ExceedMaxSubroutineDepth   of int
-    [@@deriving show]
-
     type t =
       | UnknownFormatVersion      of Value.Tag.t
       | UnknownTtcVersion         of wint
@@ -880,7 +868,15 @@ module Decode : sig
       | FdindexOutOfBounds        of int
       | FdselectOutOfBounds       of int
       | CharstringWithoutWidth
-      | InvalidCharstring         of charstring_error
+      | UnknownCharstringLongOperator of int
+      | CharstringStackUnderflow
+      | CharstringStackRemaining
+      | SubroutineIndexOutOfBounds    of { index : int; biased : int }
+      | NoSubroutineIndexArgument
+      | CharstringParsingOverrun      of int
+      | NotAMiddleOfPathInCharstring
+      | EmptyCurveInCharstring
+      | ExceedMaxSubroutineDepth      of int
       | InvalidTtfContour
       | UnknownCoverageFormat     of int
       | InvalidCoverageLength

--- a/src/otfed.mli
+++ b/src/otfed.mli
@@ -840,7 +840,7 @@ module Decode : sig
       | StackUnderflow
       | StackRemaining
       | SubroutineIndexOutOfBounds of { index : int; biased : int }
-      | NoSubroutineIndex
+      | NoSubroutineIndex          of string
       | ParsingOverrun             of int
       | NotAMiddleOfPath
       | EmptyRestOfCurve

--- a/src/otfed.mli
+++ b/src/otfed.mli
@@ -844,6 +844,7 @@ module Decode : sig
       | ParsingOverrun             of int
       | NotAMiddleOfPath
       | EmptyRestOfCurve
+      | ExceedMathDepthLimit       of int
     [@@deriving show]
 
     type t =

--- a/src/otfed.mli
+++ b/src/otfed.mli
@@ -844,7 +844,7 @@ module Decode : sig
       | ParsingOverrun             of int
       | NotAMiddleOfPath
       | EmptyRestOfCurve
-      | ExceedMathDepthLimit       of int
+      | ExceedMaxSubroutineDepth   of int
     [@@deriving show]
 
     type t =


### PR DESCRIPTION
* Fix how to prevent infinite loops when parsing CharStrings
* Fix how to encode `OS/2` tables about `fsSelection` and the table version
* Fix how to encode composite glyphs in `glyf` about `int8` entries