### PR TITLE
Fix installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
           - macos-latest
           - ubuntu-latest
         ocaml-compiler:
-          - 4.11.x
           - 4.12.x
           - 4.13.x
+          - 4.14.x
 
     runs-on: ${{ matrix.os }}
 

--- a/dune-project
+++ b/dune-project
@@ -14,6 +14,7 @@
  (synopsis "An OpenType encoder/decoder for OCaml")
  (description "")
  (depends
+  (ocaml (>= 4.12))
   (dune (>= 2.0))
   (base (>= v0.15.0))
   (stdio (>= v0.15.0))

--- a/otfed.opam
+++ b/otfed.opam
@@ -9,6 +9,7 @@ license: "MIT"
 homepage: "https://github.com/gfngfn/otfed"
 bug-reports: "https://github.com/gfngfn/otfed/issues"
 depends: [
+  "ocaml" {>= "4.12"}
   "dune" {>= "2.7" & >= "2.0"}
   "base" {>= "v0.15.0"}
   "stdio" {>= "v0.15.0"}

--- a/src/decodeOperation.ml
+++ b/src/decodeOperation.ml
@@ -316,5 +316,5 @@ let%test_unit "chop_two_bytes" =
   in
   cases |> List.iter (fun (data, unit_size, repeat, expected) ->
     let got = chop_two_bytes ~data ~unit_size ~repeat in
-    Alcotest.(check (list int)) "chop_two_bytes" expected got
+    assert (List.equal Int.equal expected got)
   )

--- a/src/dune
+++ b/src/dune
@@ -1,6 +1,8 @@
 (library
  (name otfed)
- (inline_tests)
+ (inline_tests
+   (libraries
+     alcotest))
  (public_name otfed)
  (libraries
    base)

--- a/src/dune
+++ b/src/dune
@@ -3,8 +3,7 @@
  (inline_tests)
  (public_name otfed)
  (libraries
-   base
-   alcotest)
+   base)
  (preprocess
    (pps
      ppx_deriving.show

--- a/src/dune
+++ b/src/dune
@@ -1,8 +1,6 @@
 (library
  (name otfed)
- (inline_tests
-   (libraries
-     alcotest))
+ (inline_tests)
  (public_name otfed)
  (libraries
    base)

--- a/src/encodePost.ml
+++ b/src/encodePost.ml
@@ -114,7 +114,10 @@ let make ~(num_glyphs : int) (post : Value.Post.t) =
 
 
 let%test_unit "make_index_list_and_name_list" =
+  let pair_equal equal1 equal2 (x1, y1) (x2, y2) = equal1 x1 x2 && equal2 y1 y2 in
+
   let input = [".notdef"; "foo"; "bar"; "baz"] in
-  let got = make_index_list_and_name_list input in
   let expected = ([0; 258; 95; 259], ["foo"; "baz"]) in
-  Alcotest.(check (pair (list int) (list string))) "make_index_list_and_name_list" expected got
+
+  let got = make_index_list_and_name_list input in
+  assert (pair_equal (List.equal Int.equal) (List.equal String.equal) expected got)


### PR DESCRIPTION
```
#=== ERROR while compiling otfed.0.0.1 ========================================#
# context     2.1.3 | linux/x86_64 | ocaml-base-compiler.4.14.0 | git+https://github.com/gfngfn/satysfi-external-repo.git
# path        ~/work/SATySFi/SATySFi/_opam/.opam-switch/build/otfed.0.0.1
# command     ~/.opam/opam-init/hooks/sandbox.sh build dune build -p otfed -j 2 @install
# exit-code   1
# env-file    ~/.opam/log/otfed-5062-9b6e1f.env
# output-file ~/.opam/log/otfed-5062-9b6e1f.out
### output ###
# File "src/dune", line 7, characters 3-11:
# 7 |    alcotest)
#        ^^^^^^^^
# Error: Library "alcotest" not found.
# -> required by library "otfed" in _build/default/src
# -> required by _build/default/META.otfed
# -> required by _build/install/default/lib/otfed/META
# -> required by _build/default/otfed.install
# -> required by alias install
```