### PR TITLE
Make `loca` distinguish "empty glyphs" from "undefined"

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -215,7 +215,10 @@ let get_simple_glyph (ttf : D.ttf_source) (gid : V.glyph_id) =
   | None ->
       return None
 
-  | Some(loc) ->
+  | Some(I.Ttf.EmptyGlyph) ->
+      return None
+
+  | Some(I.Ttf.NonemptyGlyph(loc)) ->
       D.Ttf.glyf ttf loc |> inj >>= fun { description = descr; _ } ->
       match descr with
       | V.Ttf.CompositeGlyph(_)   -> return None
@@ -236,7 +239,11 @@ let print_glyf (source : D.source) (gid : V.glyph_id) (path : string) =
           Format.printf "  not defined@,";
           return ()
 
-      | Some(loc) ->
+      | Some(I.Ttf.EmptyGlyph) ->
+          Format.printf "  empty glyph@,";
+          return ()
+
+      | Some(I.Ttf.NonemptyGlyph(loc)) ->
           D.Head.get source |> inj >>= fun head ->
           let units_per_em = head.I.Head.value.V.Head.units_per_em in
           D.Hmtx.get source |> inj >>= fun ihmtx ->

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -218,7 +218,7 @@ let get_simple_glyph (ttf : D.ttf_source) (gid : V.glyph_id) =
   | Some(I.Ttf.EmptyGlyph) ->
       return None
 
-  | Some(I.Ttf.NonemptyGlyph(loc)) ->
+  | Some(I.Ttf.GlyphLocation(loc)) ->
       D.Ttf.glyf ttf loc |> inj >>= fun { description = descr; _ } ->
       match descr with
       | V.Ttf.CompositeGlyph(_)   -> return None
@@ -243,7 +243,7 @@ let print_glyf (source : D.source) (gid : V.glyph_id) (path : string) =
           Format.printf "  empty glyph@,";
           return ()
 
-      | Some(I.Ttf.NonemptyGlyph(loc)) ->
+      | Some(I.Ttf.GlyphLocation(loc)) ->
           D.Head.get source |> inj >>= fun head ->
           let units_per_em = head.I.Head.value.V.Head.units_per_em in
           D.Hmtx.get source |> inj >>= fun ihmtx ->

--- a/src/decodeTtf.ml
+++ b/src/decodeTtf.ml
@@ -61,7 +61,8 @@ let loca (ttf : ttf_source) (gid : glyph_id) : (Intermediate.Ttf.loca_entry opti
       return @@ Some(Intermediate.Ttf.EmptyGlyph)
 
   | Some(Some(reloffset, length)) ->
-      return @@ Some(Intermediate.Ttf.(NonemptyGlyph(GlyphLocation{ reloffset; length })))
+      let loc = Intermediate.Ttf.GlyphLocationData{ reloffset; length } in
+      return @@ Some(Intermediate.Ttf.GlyphLocation(loc))
 
 
 let d_end_points (numberOfContours : int) : (int Alist.t) decoder =
@@ -329,7 +330,7 @@ let glyf (ttf : ttf_source) (gloc : Intermediate.Ttf.glyph_location) : Ttf.glyph
   let open ResultMonad in
   let common = ttf.ttf_common in
   DecodeOperation.seek_required_table common.table_directory Value.Tag.table_glyf >>= fun (offset, _length) ->
-  let (Intermediate.Ttf.GlyphLocation{ reloffset; length }) = gloc in
+  let Intermediate.Ttf.GlyphLocationData{ reloffset; length } = gloc in
   d_glyph ~length |> DecodeOperation.run common.core (offset + reloffset)
 
 

--- a/src/decodeTtf.mli
+++ b/src/decodeTtf.mli
@@ -5,9 +5,9 @@ open DecodeOperation.Open
 
 module Maxp : (module type of DecodeTtfMaxp)
 
-val d_loca : num_glyphs:int -> Intermediate.loc_format -> glyph_id -> ((int * int) option) decoder
+val d_loca : num_glyphs:int -> Intermediate.loc_format -> glyph_id -> (((int * int) option) option) decoder
 
-val loca : ttf_source -> glyph_id -> (Intermediate.Ttf.glyph_location option) ok
+val loca : ttf_source -> glyph_id -> (Intermediate.Ttf.loca_entry option) ok
 
 val d_glyph : length:int -> Ttf.glyph_info decoder
 

--- a/src/intermediate.ml
+++ b/src/intermediate.ml
@@ -86,12 +86,12 @@ module Ttf = struct
   end
 
   type glyph_location =
-    | GlyphLocation of { reloffset : int; length : int }
+    | GlyphLocationData of { reloffset : int; length : int }
   [@@deriving show { with_path = false }]
 
   type loca_entry =
     | EmptyGlyph
-    | NonemptyGlyph of glyph_location
+    | GlyphLocation of glyph_location
   [@@deriving show { with_path = false }]
 
   type flag = {

--- a/src/intermediate.ml
+++ b/src/intermediate.ml
@@ -89,6 +89,11 @@ module Ttf = struct
     | GlyphLocation of { reloffset : int; length : int }
   [@@deriving show { with_path = false }]
 
+  type loca_entry =
+    | EmptyGlyph
+    | NonemptyGlyph of glyph_location
+  [@@deriving show { with_path = false }]
+
   type flag = {
     on_curve       : bool;
     x_short_vector : bool;

--- a/src/otfed.mli
+++ b/src/otfed.mli
@@ -647,7 +647,7 @@ module Intermediate : sig
     (** The type for entries in [loca] tables. See [Decode.Ttf.loca]. *)
     type loca_entry =
       | EmptyGlyph
-      | NonemptyGlyph of glyph_location
+      | GlyphLocation of glyph_location
     [@@deriving show]
   end
 

--- a/src/otfed.mli
+++ b/src/otfed.mli
@@ -641,8 +641,14 @@ module Intermediate : sig
       [@@deriving show]
     end
 
-    (** The type for entries in [loca] tables. See [Decode.Ttf.loca]. *)
+    (** The type for non-empty glyph entries in [loca] tables. See [Decode.Ttf.loca]. *)
     type glyph_location
+
+    (** The type for entries in [loca] tables. See [Decode.Ttf.loca]. *)
+    type loca_entry =
+      | EmptyGlyph
+      | NonemptyGlyph of glyph_location
+    [@@deriving show]
   end
 
   (** Defines types for representing CFF-based tables. *)
@@ -1283,7 +1289,7 @@ module Decode : sig
 
     (** [loca ttf gid] consults the [loca] table of the source [ttf] by glyph ID [gid],
         and returns the location of the glyph in the [glyf] table if exists.  *)
-    val loca : ttf_source -> Value.glyph_id -> (Intermediate.Ttf.glyph_location option) ok
+    val loca : ttf_source -> Value.glyph_id -> (Intermediate.Ttf.loca_entry option) ok
 
     (** [glyf ttf loc] accesses [loca] in the [glyf] table and
         returns the bounding box and the outline of the glyph. *)
@@ -1442,7 +1448,7 @@ module Encode : sig
     type glyph_relative_offset
 
     (** Encodes a [glyf] table and produces glyph locations that will constitute a [loca] table. *)
-    val make_glyf : Value.Ttf.glyph_info list -> (table * glyph_relative_offset list) ok
+    val make_glyf : (Value.Ttf.glyph_info option) list -> (table * glyph_relative_offset list) ok
 
     (** Encodes a [loca] table and produces a value for the [indexToLocFormat] entry of the [head] table. *)
     val make_loca : glyph_relative_offset list -> (table * Intermediate.loc_format) ok

--- a/src/subset.ml
+++ b/src/subset.ml
@@ -31,7 +31,7 @@ let get_ttf_glyph (ttf : Decode.ttf_source) (gid : glyph_id) : (Ttf.glyph_info o
   | Some(Intermediate.Ttf.EmptyGlyph) ->
       return None
 
-  | Some(Intermediate.Ttf.NonemptyGlyph(loc)) ->
+  | Some(Intermediate.Ttf.GlyphLocation(loc)) ->
       inj_dec @@ Decode.Ttf.glyf ttf loc >>= fun g ->
       return @@ Some(g)
 

--- a/src/subset.ml
+++ b/src/subset.ml
@@ -22,39 +22,51 @@ let inj_dec d = Result.map_error (fun e -> Error.DecodeError(e)) d
 let inj_enc e = Result.map_error (fun e -> Error.EncodeError(e)) e
 
 
-let get_ttf_glyph (ttf : Decode.ttf_source) (gid : glyph_id) : Ttf.glyph_info ok =
+let get_ttf_glyph (ttf : Decode.ttf_source) (gid : glyph_id) : (Ttf.glyph_info option) ok =
   let open ResultMonad in
   inj_dec @@ Decode.Ttf.loca ttf gid >>= function
-  | None      -> err @@ Error.GlyphNotFound(gid)
-  | Some(loc) -> inj_dec @@ Decode.Ttf.glyf ttf loc
+  | None ->
+      err @@ Error.GlyphNotFound(gid)
+
+  | Some(Intermediate.Ttf.EmptyGlyph) ->
+      return None
+
+  | Some(Intermediate.Ttf.NonemptyGlyph(loc)) ->
+      inj_dec @@ Decode.Ttf.glyf ttf loc >>= fun g ->
+      return @@ Some(g)
 
 
-type glyph_accumulator = (glyph_id * Ttf.glyph_info) Alist.t * bounding_box
+type glyph_accumulator = (glyph_id * Ttf.glyph_info option) Alist.t * bounding_box option
 
 
-let folding_ttf_glyph (ttf : Decode.ttf_source) ((ggs, bbox_all) : glyph_accumulator) (gid : glyph_id) : glyph_accumulator ok =
+let folding_ttf_glyph (ttf : Decode.ttf_source) ((ggs, bbox_all_opt) : glyph_accumulator) (gid : glyph_id) : glyph_accumulator ok =
   let open ResultMonad in
-  get_ttf_glyph ttf gid >>= fun g ->
-  return (Alist.extend ggs (gid, g), unite_bounding_boxes bbox_all g.bounding_box)
+  get_ttf_glyph ttf gid >>= fun g_opt ->
+  let bbox_all_opt =
+    match (g_opt, bbox_all_opt) with
+    | (None, None)              -> None
+    | (None, _)                 -> bbox_all_opt
+    | (Some(g), None)           -> Some(g.bounding_box)
+    | (Some(g), Some(bbox_all)) -> Some(unite_bounding_boxes bbox_all g.bounding_box)
+  in
+  return (Alist.extend ggs (gid, g_opt), bbox_all_opt)
 
 
-let get_ttf_glyphs (ttf : Decode.ttf_source) (gids : glyph_id list) : ((glyph_id * Ttf.glyph_info) list * bounding_box) ok =
+let get_ttf_glyphs (ttf : Decode.ttf_source) (gids : glyph_id list) : ((glyph_id * Ttf.glyph_info option) list * bounding_box) ok =
   let open ResultMonad in
-  match gids with
-  | [] ->
-      err Error.NoGlyphGiven
-
-  | gid_first :: gids_tail ->
-      get_ttf_glyph ttf gid_first >>= fun g_first ->
-      foldM (folding_ttf_glyph ttf) gids_tail (Alist.empty, g_first.bounding_box) >>= fun (gs_tail, bbox_all) ->
-      let gs = (gid_first, g_first) :: Alist.to_list gs_tail in
-      return (gs, bbox_all)
+  foldM (folding_ttf_glyph ttf) gids (Alist.empty, None) >>= fun (gs, bbox_all_opt) ->
+  let bbox_all =
+    match bbox_all_opt with
+    | None           -> { x_min = 0; y_min = 0; x_max = 0; y_max = 0 }
+    | Some(bbox_all) -> bbox_all
+  in
+  return (Alist.to_list gs, bbox_all)
 
 
 module OldToNew = Map.Make(Int)
 
 
-let edit_composite_glyphs (ggs : (glyph_id * Ttf.glyph_info) list) =
+let edit_composite_glyphs (ggs : (glyph_id * Ttf.glyph_info option) list) =
   let open ResultMonad in
   let (_, old_to_new) =
     ggs |> List.fold_left (fun (gid_new, old_to_new) (gid_old, _) ->
@@ -62,25 +74,31 @@ let edit_composite_glyphs (ggs : (glyph_id * Ttf.glyph_info) list) =
     ) (0, OldToNew.empty)
   in
   ggs |> mapM (fun gg_old ->
-    let (gid_old, g_old) = gg_old in
-    let Ttf.{ bounding_box = bbox; description = descr_old } = g_old in
-    match descr_old with
-    | Ttf.SimpleGlyph(_) ->
+    let (gid_old, g_opt_old) = gg_old in
+    match g_opt_old with
+    | None ->
         return gg_old
 
-    | Ttf.CompositeGlyph(composite_glyph) ->
-        let composite_elems_old = composite_glyph.Value.Ttf.composite_components in
-        composite_elems_old |> mapM (fun component ->
-          let gid_elem_old = component.Value.Ttf.component_glyph_id in
-          match old_to_new |> OldToNew.find_opt gid_elem_old with
-          | None ->
-              err @@ Error.DependentGlyphNotFound{ depending = gid_old; depended = gid_elem_old }
+    | Some(g_old) ->
+        let Ttf.{ bounding_box = bbox; description = descr_old } = g_old in
+        match descr_old with
+        | Ttf.SimpleGlyph(_) ->
+            return gg_old
 
-          | Some(gid_elem_new) ->
-              return Value.Ttf.{ component with component_glyph_id =  gid_elem_new }
-        ) >>= fun composite_components ->
-        let composite_glyph_new = { composite_glyph with composite_components } in
-        return (gid_old, Ttf.{ bounding_box = bbox; description = Ttf.CompositeGlyph(composite_glyph_new) })
+        | Ttf.CompositeGlyph(composite_glyph) ->
+            let composite_elems_old = composite_glyph.Value.Ttf.composite_components in
+            composite_elems_old |> mapM (fun component ->
+              let gid_elem_old = component.Value.Ttf.component_glyph_id in
+              match old_to_new |> OldToNew.find_opt gid_elem_old with
+              | None ->
+                  err @@ Error.DependentGlyphNotFound{ depending = gid_old; depended = gid_elem_old }
+
+              | Some(gid_elem_new) ->
+                  return Value.Ttf.{ component with component_glyph_id =  gid_elem_new }
+            ) >>= fun composite_components ->
+            let composite_glyph_new = { composite_glyph with composite_components } in
+            let g_new = Ttf.{ bounding_box = bbox; description = Ttf.CompositeGlyph(composite_glyph_new) } in
+            return (gid_old, Some(g_new))
   )
 
 
@@ -110,7 +128,7 @@ let update_derived ~current:derived ~new_one:derived_new =
   }
 
 
-let get_ttf_hmtx (ihmtx : Decode.Hmtx.t) ((gid, g) : glyph_id * Ttf.glyph_info) : (Intermediate.Hhea.derived * hmtx_entry * design_units) ok =
+let get_ttf_hmtx (ihmtx : Decode.Hmtx.t) ((gid, g_opt) : glyph_id * Ttf.glyph_info option) : (Intermediate.Hhea.derived * hmtx_entry * design_units) ok =
   let open ResultMonad in
   inj_dec @@ Decode.Hmtx.access ihmtx gid >>= function
   | None ->
@@ -118,8 +136,11 @@ let get_ttf_hmtx (ihmtx : Decode.Hmtx.t) ((gid, g) : glyph_id * Ttf.glyph_info) 
 
   | Some((aw, lsb) as entry) ->
       let derived =
-        let x_min = g.bounding_box.x_min in
-        let x_max = g.bounding_box.x_max in
+        let (x_min, x_max) =
+          match g_opt with
+          | None    -> (0, 0)
+          | Some(g) -> (g.bounding_box.x_min, g.bounding_box.x_max)
+        in
         let extent = x_max - x_min in
         let rsb = aw - lsb - extent in
         Intermediate.Hhea.{
@@ -132,7 +153,7 @@ let get_ttf_hmtx (ihmtx : Decode.Hmtx.t) ((gid, g) : glyph_id * Ttf.glyph_info) 
       return (derived, entry, aw)
 
 
-let folding_ttf_hmtx (ihmtx : Decode.Hmtx.t) (acc : hmtx_accumulator) (gg : glyph_id * Ttf.glyph_info) : hmtx_accumulator ok =
+let folding_ttf_hmtx (ihmtx : Decode.Hmtx.t) (acc : hmtx_accumulator) (gg : glyph_id * Ttf.glyph_info option) : hmtx_accumulator ok =
   let open ResultMonad in
   let derived = acc.current_hhea_derived in
   get_ttf_hmtx ihmtx gg >>= fun (derived_new, entry, aw) ->
@@ -145,7 +166,7 @@ let folding_ttf_hmtx (ihmtx : Decode.Hmtx.t) (acc : hmtx_accumulator) (gg : glyp
       }
 
 
-let make_ttf_hmtx (src : Decode.source) (ggs : (glyph_id * Ttf.glyph_info) list) : hmtx_result ok =
+let make_ttf_hmtx (src : Decode.source) (ggs : (glyph_id * Ttf.glyph_info option) list) : hmtx_result ok =
   let open ResultMonad in
   inj_dec @@ Decode.Hmtx.get src >>= fun ihmtx ->
   match ggs with

--- a/test/otfedTest.ml
+++ b/test/otfedTest.ml
@@ -251,7 +251,7 @@ let d_loca_tests () =
   TestCaseLoca1.cases |> List.iter (fun (gid, expected) ->
     let num_glyphs = TestCaseLoca1.num_glyphs in
     let got = DecodeTtf.d_loca ~num_glyphs TestCaseLoca1.loc_format gid |> run_decoder TestCaseLoca1.marshaled in
-    Alcotest.(check (decoding (option (pair int int)))) "d_loca" expected got
+    Alcotest.(check (decoding (option (option (pair int int))))) "d_loca" expected got
   )
 
 

--- a/test/testCaseLoca1.ml
+++ b/test/testCaseLoca1.ml
@@ -31,8 +31,8 @@ let loc_format = Intermediate.LongLocFormat
 let cases =
   [
     (-1, Ok(None));
-    (0, Ok(Some((0, 160))));
-    (1, Ok(None));
-    (4, Ok(Some((160, 124))));
+    (0, Ok(Some(Some((0, 160)))));
+    (1, Ok(Some(None)));
+    (4, Ok(Some(Some((160, 124)))));
     (50, Ok(None));
   ]


### PR DESCRIPTION
Closes https://github.com/gfngfn/otfed/issues/28

Context: Building [*The SATySFibook*](https://github.com/gfngfn/the_satysfibook) with SATySFi 0.0.8 fails like the following:

```console
 ---- ---- ---- ----
  embedding fonts ...
! [Error] font file 'ipaexm.ttf' is broken;
      pdfstream_of_decoder: (GlyphNotFound 399)
```

The glyph of GID 399 in `ipaexm.ttf` is a full-width space. The unintended failure above seems to be due to confusion of empty glyphs with undefinedness.