### PR TITLE
Fix how to decode GSubrs dependent on LSubrs

### DIFF
--- a/src/otfed.mli
+++ b/src/otfed.mli
@@ -1592,7 +1592,9 @@ module Subset : sig
       | DecodeError                 of Decode.Error.t
       | EncodeError                 of Encode.Error.t
       | NonexplicitSubroutineNumber
+          (** Returned when [callgsubr] or [callsubr] does not follow immediately after a subroutine number. *)
       | CallSubrInGlobalSubr        of { old_biased : int }
+          (** Returned when a Global Subr depends on non-FDArray Local Subrs. *)
     [@@deriving show]
   end
 


### PR DESCRIPTION
For example, in `lmmono10-regular.otf`, GSubrs are indeed dependent upon its non-FDArray LSubrs.

We do NOT support GSubrs dependent on FDArray LSubrs, on the other hand, at least for the moment. It is even doubtful that such a font exists.